### PR TITLE
Add MySQL configuration via YAML

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=gestionlivre

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  application:
+    name: gestionlivre
+  datasource:
+    url: jdbc:mysql://localhost:3306/gestionlivre
+    username: root
+    password: root
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
## Summary
- switch config to `application.yml`
- include MySQL datasource and JPA settings

## Testing
- `./mvnw -q test` *(fails: Failed to fetch Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6844af236e04833383dd7631f268a825